### PR TITLE
Feat: Integrate IMU Sensor Fusion into Main Task

### DIFF
--- a/Core/Inc/ImuSensor.h
+++ b/Core/Inc/ImuSensor.h
@@ -12,14 +12,24 @@
 #include <stdint.h>
 
 struct MPU_DATA{
+
 	float AccX;
 	float AccY;
 	float AccZ;
+
+	float totalforce;
+
 	float gyX;
 	float gyY;
 	float gyZ;
-	float totalforce;
+
+	float pitch;
+	float roll;
+	float yaw;//accel cant messure yaw angle information confirmation is missing.
 };
+
+
+
 
 
 class ImuSensor {
@@ -30,10 +40,20 @@ public:
 	void readAccel();
 	void readGyro();
 	MPU_DATA getData();
-
+	void angleMeasurement();
 
 private:
 
+	//Variables for angular estimation and time measurement
+	uint32_t _prevTime;
+
+	float _alpha;
+	float _dt;
+	float _compAngle=0;
+
+	//ANGLEDATA angle_data;
+
+	//sensor read variables
 	MPU_DATA mpu_data;
 	I2C_HandleTypeDef* _i2c;
 	HAL_StatusTypeDef mpu_status;

--- a/Core/Src/AppMain.cpp
+++ b/Core/Src/AppMain.cpp
@@ -47,17 +47,17 @@ if(!scan){
 }
 
     led1.toggle();
-    osDelay(150);
     mpu_6050.readAccel();
     mpu_6050.readGyro();
 
+    mpu_6050.angleMeasurement();
 
     MPU_DATA data = mpu_6050.getData();
 
+    //this messages keeps processor bussy a lot . These are cancelled.
+    //printf("X: %.2f | Y: %.2f | Z: %.2f | Total: %.2f\r\n",data.AccX, data.AccY, data.AccZ, data.totalforce);
+    //printf("Gyro: X:%.1f Y:%.1f Z:%.1f\r\n",data.gyX, data.gyY, data.gyZ);
 
-    printf("X: %.2f | Y: %.2f | Z: %.2f | Total: %.2f\r\n",
-           data.AccX, data.AccY, data.AccZ, data.totalforce);
-
-    printf("Gyro: X:%.1f Y:%.1f Z:%.1f\r\n",
-           data.gyX, data.gyY, data.gyZ);
+    //For now Im using a plain printf with a standard UART baud rate of 115200. It keeps the processor busy for about 2.5ms per message. With an osdelay of 4ms, there's still enough time for processing. Im skipping DMA usage for now I'll come back to work on it.
+    printf("Pitch: %.2f | Roll: %.2f\r\n", data.pitch, data.roll);
 }


### PR DESCRIPTION
I integrated the ImuSensor class into App_Sensor_Task with initialization and error handling logic. I enabled the complementary filter execution (angleMeasurement) and optimized UART logging. I commented out raw sensor data prints to reduce blocking time (approx 2.5ms @ 115200 baud) and focused on outputting calculated Pitch/Roll values. I also documented the blocking nature of printf and the decision to defer DMA implementation.