### PR TITLE
Implement Compass Driver & Yaw Sensor Fusion ( #14)

### DIFF
--- a/Core/Inc/Compass.h
+++ b/Core/Inc/Compass.h
@@ -1,0 +1,33 @@
+/*
+ * Compass.h
+ *
+ *  Created on: Mar 15, 2026
+ *      Author: yufur
+ */
+
+#ifndef INC_COMPASS_H_
+#define INC_COMPASS_H_
+
+#define COMPASS_REG_CONTROL 0x09
+#define COMPASS_REG_DATA    0x00
+#define COMPASS_I2C_ADDR    (0x2C << 1) // (0x58)
+
+#include "main.h"
+
+class Compass {
+public:
+    Compass(I2C_HandleTypeDef* i2cHandle);
+
+    bool init();
+    void read();
+    float getYaw();
+
+
+private:
+    I2C_HandleTypeDef* _i2c;
+    float _heading;
+    int16_t magX , magY, magZ;
+
+};
+
+#endif /* INC_COMPASS_H_ */

--- a/Core/Inc/ImuSensor.h
+++ b/Core/Inc/ImuSensor.h
@@ -40,7 +40,7 @@ public:
 	void readAccel();
 	void readGyro();
 	MPU_DATA getData();
-	void angleMeasurement();
+	void angleMeasurement(float heading);
 
 private:
 

--- a/Core/Src/AppMain.cpp
+++ b/Core/Src/AppMain.cpp
@@ -16,6 +16,7 @@
 #include "SystemManager.h"
 #include "Mixer.h"
 #include "IbusReader.h"
+#include "Compass.h"
 
 extern I2C_HandleTypeDef hi2c1;// for line of ImuSensor mpu_6050(&hi2c1);
 extern UART_HandleTypeDef huart2;
@@ -27,6 +28,8 @@ extern UART_HandleTypeDef huart6;//using for fs ia6b reciver line
 
 StatusLed led1(LD2_GPIO_Port, LD2_Pin);
 ImuSensor mpu_6050(&hi2c1);
+Compass compass(&hi2c1);
+
 
 float servo_minout= -20.0f;
 float servo_maxout=  20.0f;
@@ -38,17 +41,21 @@ float motor_maxout= 100.0f;
 
 Pid pid_roll(1.5f, 0.01f, 0.5f ,servo_minout, servo_maxout);
 Pid pid_pitch(1.8f, 0.02f, 0.6f,servo_minout, servo_maxout);
+Pid pid_yaw(1.8f, 0.02f, 0.6f,servo_minout, servo_maxout);
+
 ActuatorMixer mixer(servo_minout, servo_maxout,motor_minout,motor_maxout);
 
 RCState currentState;
 PIDOuts pidCommands;
 IbusReader ibus;
 
+
 uint8_t ibus_dma_buffer[IBUS_DMA_BUFFER];
 
 void App_Main_Start(void)
 {
 	System_Init();
+	compass.init();
 
 	//I will transfer into fuct later----
 	//dummy commands erased. uart6 dma way is open
@@ -99,7 +106,8 @@ void App_Sensor_Task(void)
 
     mpu_6050.readAccel();
     mpu_6050.readGyro();
-    mpu_6050.angleMeasurement();
+    compass.read();
+    mpu_6050.angleMeasurement(compass.getYaw());
     MPU_DATA data = mpu_6050.getData();
 
     float dt=0.004f;//osDelay(4)->0.004f
@@ -109,6 +117,8 @@ void App_Sensor_Task(void)
 
     pidCommands.servo_roll_out = pid_roll.compute(currentState.roll, data.roll, dt);
     pidCommands.servo_pitch_out= pid_pitch.compute(currentState.pitch, data.pitch, dt);
+    pidCommands.servo_yaw_out= pid_yaw.compute(currentState.yaw, data.yaw, dt);
+
 
     mixer.compute(currentState, pidCommands);
     ActuatorState_t pwm_outputs = mixer.getState();

--- a/Core/Src/Compass.cpp
+++ b/Core/Src/Compass.cpp
@@ -1,0 +1,62 @@
+/*
+ * Compass.cpp
+ *
+ *  Created on: Mar 15, 2026
+ *      Author: yufur
+ */
+
+#include "Compass.h"
+#include <math.h>
+
+
+//#define COMPASS_REG_CONTROL 0x09
+//#define COMPASS_REG_DATA    0x00
+//#define COMPASS_I2C_ADDR    (0x2C << 1) // (0x58)
+
+
+
+Compass::Compass(I2C_HandleTypeDef* i2cHandle) {
+	_i2c = i2cHandle;
+	magX = 0; magY = 0; magZ = 0;
+	_heading = 0.0f;
+
+}
+
+bool Compass::init() {
+
+	uint8_t initData = 0x1D; //<--2C<<1
+
+	HAL_StatusTypeDef status = HAL_I2C_Mem_Write(_i2c, COMPASS_I2C_ADDR, COMPASS_REG_CONTROL, 1, &initData, 1, 100);
+
+	return (status == HAL_OK);
+}
+
+void Compass::read() {
+
+	uint8_t buffer[6];
+	HAL_StatusTypeDef status = HAL_I2C_Mem_Read(_i2c, COMPASS_I2C_ADDR, COMPASS_REG_DATA, 1, buffer, 6, 100);
+
+
+	if(status==HAL_OK){
+		magX=((int16_t)(buffer[0]|(buffer[1])<<8));
+		magY=((int16_t)(buffer[2]|(buffer[3])<<8));
+		magZ=((int16_t)(buffer[4]|(buffer[5])<<8));
+
+		_heading = atan2((float)magY, (float)magX) * (180.0f / 3.14159265f);
+	}
+
+
+
+	if (_heading < 0.0f) {
+		_heading += 360.0f;
+	}
+
+
+}
+
+float Compass::getYaw() {
+    return _heading;
+}
+
+
+

--- a/Core/Src/ImuSensor.cpp
+++ b/Core/Src/ImuSensor.cpp
@@ -43,7 +43,7 @@ bool ImuSensor::init() {
 	return 0;
 }
 
-void ImuSensor::angleMeasurement(){
+void ImuSensor::angleMeasurement(float heading){
 
 
 	_dt=(HAL_GetTick()-_prevTime)/1000.0;
@@ -60,6 +60,7 @@ void ImuSensor::angleMeasurement(){
 
 	mpu_data.roll = _alpha * (mpu_data.roll + mpu_data.gyX * _dt) + (1.0f - _alpha) * AccRoll;
 	mpu_data.pitch= _alpha * (mpu_data.pitch+ mpu_data.gyY * _dt) + (1.0f - _alpha) * AccPitch;
+	mpu_data.yaw  = _alpha * (mpu_data.yaw+ mpu_data.gyZ * _dt)   + (1.0f - _alpha) * heading;
 
 
 	_prevTime=HAL_GetTick();


### PR DESCRIPTION
 - Created a decoupled, bare-metal driver to read raw X, Y, Z magnetic vectors.
 - Implemented `atan2` trigonometry to calculate the absolute magnetic heading (Yaw).

 - Upgraded the `angleMeasurement` function to accept an external compass heading.
 - Implemented a standard Complementary Filter (`Yaw = 0.96 * Gyro_Yaw + 0.04 * Compass_Yaw`) to eliminate gyroscope drift while maintaining lightning-fast reaction times.

 - Instantiated the `Compass` object and integrated it into the 250Hz `App_Sensor_Task`.
 - Fixed missing pointers and macro definitions to ensure a clean, 0-error compilation.



Closes #14